### PR TITLE
Update lib/shortener/active_record_extension.rb

### DIFF
--- a/lib/shortener/active_record_extension.rb
+++ b/lib/shortener/active_record_extension.rb
@@ -1,5 +1,5 @@
 module Shortener::ActiveRecordExtension
   def has_shortened_urls
-    has_many :shortened_urls, :class_name => ::Shortener::ShortenedUrl, :as => :owner
+    has_many :shortened_urls, :class_name => "::Shortener::ShortenedUrl", :as => :owner
   end
 end


### PR DESCRIPTION
:class_name expects a string, not a class
