### PR TITLE
duplicate links

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -18,7 +18,7 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   # generate a shortened link from a url
   # link to a user if one specified
   # throw an exception if anything goes wrong
-  def self.generate!(orig_url, owner=nil)
+  def self.generate!(orig_url, owner=nil, unique=true)
     # if we get a shortened_url object with a different owner, generate
     # new one for the new owner. Otherwise return same object
     if orig_url.is_a?(Shortener::ShortenedUrl)
@@ -29,13 +29,18 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
     # so check the datastore
     cleaned_url = clean_url(orig_url)
     scope = owner ? owner.shortened_urls : self
-    scope.where(:url => cleaned_url).first_or_create
+
+    if unique
+      scope.where(:url => cleaned_url).first_or_create
+    else
+      scope.create(:url => cleaned_url)
+    end
   end
 
   # return shortened url on success, nil on failure
-  def self.generate(orig_url, owner=nil)
+  def self.generate(orig_url, owner=nil, unique=true)
     begin
-      generate!(orig_url, owner)
+      generate!(orig_url, owner, unique)
     rescue
       nil
     end

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -65,4 +65,18 @@ describe Shortener::ShortenedUrl do
       end
     end
   end
+
+  context "diplicate shortened URLs" do
+    it "shouldn't create duplicate urls" do
+      Shortener::ShortenedUrl.generate!(some_url)
+      Shortener::ShortenedUrl.generate!(some_url)
+      Shortener::ShortenedUrl.count.should == 1
+    end
+
+    it "should create duplicate urls" do
+      Shortener::ShortenedUrl.generate!(some_url, false)
+      Shortener::ShortenedUrl.generate!(some_url, false)
+      Shortener::ShortenedUrl.count.should == 2
+    end
+  end
 end


### PR DESCRIPTION
Hi. 
This patch resolves this improvement from your "future improvements" list:
"Some implementations might want duplicate links to be generated each time a user request a shortened link.".
ShortenedUrl generates unique link every time method generate is called.
