### PR TITLE
Allow all field values to be set on URL creation

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -41,6 +41,16 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
     end
   end
 
+  def self.generate_with_options!(orig_url, args = {})
+    generate(orig_url, args.fetch(:owner, nil)).update_attributes args
+  end
+
+  def self.generate_with_options(orig_url, args = {})
+    generate_with_options!(orig_url, args)
+  rescue
+    nil
+  end
+
   private
 
   # the create method changed in rails 4...


### PR DESCRIPTION
* Allows someone to create a Shortener::ShortenedUrl and specify values
for most of the fields
* Use case is for having custom (vanity) urls (i.e. http://sho.rt/custom
* instead of http://sho.rt/h4b3g)