### PR TITLE
fix that will allow rspec tests to run successfully

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ ENV["RAILS_ENV"] = "test"
 require 'shortener'
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require 'rspec/rails'
+require 'shoulda/matchers'
 require 'shoulda/matchers/integrations/rspec'
 
 Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
Currently, the rspec tests don't run successfully. There is an error that says uninitialized load constant. 
This was an issue caused probably by rails 4.1, as explained in https://github.com/thoughtbot/shoulda-matchers/issues/480

The fix is simply to add  require 'shoulda/matchers' in spec_helper.rb
