### PR TITLE
Rails 4.0.6 / 4.1.2 compatibility

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -44,10 +44,17 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   private
 
   # the create method changed in rails 4...
-  if Rails::VERSION::MAJOR >= 4
-    CREATE_METHOD_NAME = "create_record"
+  CREATE_METHOD_NAME =
+    if Rails::VERSION::MAJOR >= 4
+      # And again in 4.0.6/4.1.2
+      if ((Rails::VERSION::MINOR == 0) && (Rails::VERSION::TINY < 6)) ||
+         ((Rails::VERSION::MINOR == 1) && (Rails::VERSION::TINY < 2))
+        "create_record"
+      else
+        "_create_record"
+      end
   else
-    CREATE_METHOD_NAME = "create"
+    "create"
   end
 
   # we'll rely on the DB to make sure the unique key is really unique.

--- a/shortener.gemspec
+++ b/shortener.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = "> 1.3.6"
   s.add_dependency "rails", ">= 3.0.7"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "rspec-rails"
+  s.add_development_dependency "rspec-rails", '~> 2.99.0'
   s.add_development_dependency "shoulda-matchers"
   s.executables = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
   s.require_path = 'lib'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ ENV["RAILS_ENV"] = "test"
 require 'shortener'
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require 'rspec/rails'
-require 'shoulda/matchers/integrations/rspec'
+require 'shoulda/matchers'
 
 Rails.backtrace_cleaner.remove_silencers!
 


### PR DESCRIPTION
1. Update Rails integration to account for changed method name in recent code changes.
2. Minor change to shoulda integration.
3. Freeze RSpec at 2.x for now.
