### PR TITLE
updated URL regex to match hosts with '-' characters

### DIFF
--- a/lib/shortener/shorten_url_interceptor.rb
+++ b/lib/shortener/shorten_url_interceptor.rb
@@ -17,7 +17,7 @@ Usage:
                             'cloudfront\.net/' ].map {|r| Regexp.new(r) }
     DEFAULT_LENGTH_THRESHOLD = 20
 
-    URL_REGEX = /\b((https?):\/\/\w+\.)[-A-Z0-9+&@#\/%?=~_|$!:,.;]*[-A-Z0-9+&@#\/%=~_|$]/i
+    URL_REGEX = /\b((https?):\/\/[\w\.-]+[\.]\w+)([-A-Z0-9+&@#\/%?=~_|$!:,.;]*[-A-Z0-9+&@#\/%=~_|$])?/i
     MIME_TYPES = %w(text/plain text/html application/xhtml+xml)
 
     def initialize(opts = {})


### PR DESCRIPTION
also preserved existing semantics of non-matching hosts (i.e.:
localhost, etc).