### PR TITLE
Allow unique key to be specified

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -36,11 +36,11 @@ The majority of the Shortener consists of three parts:
 You can use the latest Rails 3 gem with the latest Shortener gem. In your Gemfile:
 
   gem 'shortener'
-  
+
 After you install Shortener run the generator:
 
   rails generate shortener
-  
+
 This generator will create a migration to create the shortened_urls table where your shortened URLs will be stored.
 
 Then add to your routes:
@@ -56,9 +56,9 @@ By default, the shortener will generate keys that are 5 characters long. You can
 == Usage
 
 To generate a Shortened URL object for the URL "http://dealush.com" within your controller / models do the following:
-  
+
   Shortener::ShortenedUrl.generate("http://dealush.com")
-  
+
 or
 
   Shortener::ShortenedUrl.generate("dealush.com")
@@ -66,7 +66,7 @@ or
 To generate and display a shortened URL in your application use the helper method:
 
   short_url("dealush.com")
-  
+
 This will generate a shortened URL. store it to the db and return a string representing the shortened URL.
 
 === Shortened URLs with owner
@@ -84,6 +84,12 @@ This will allow you to pass the owner when generating URLs:
 And to access those URLs:
 
   user.shortened_urls
+
+=== Shortened URLs with custom unqiue key
+
+You can pass in your own key when generating a shortened URL. This should be unique.
+
+  Shortener::ShortenedUrl.generate("dealush.com", user, "my-key")
 
 === Shorten URLs in generated emails
 

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -64,6 +64,8 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   # we'll rely on the DB to make sure the unique key is really unique.
   # if it isn't unique, the unique index will catch this and raise an error
   define_method CREATE_METHOD_NAME do
+    return super() if self.unique_key
+
     count = 0
     begin
       self.unique_key = generate_unique_key

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -18,24 +18,28 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   # generate a shortened link from a url
   # link to a user if one specified
   # throw an exception if anything goes wrong
-  def self.generate!(orig_url, owner=nil)
+  def self.generate!(orig_url, owner=nil, custom_key=nil)
     # if we get a shortened_url object with a different owner, generate
     # new one for the new owner. Otherwise return same object
     if orig_url.is_a?(Shortener::ShortenedUrl)
-      return orig_url.owner == owner ? orig_url : generate!(orig_url.url, owner)
+      return orig_url.owner == owner ? orig_url : generate!(orig_url.url, owner, custom_key)
     end
 
     # don't want to generate the link if it has already been generated
     # so check the datastore
     cleaned_url = clean_url(orig_url)
     scope = owner ? owner.shortened_urls : self
-    scope.where(:url => cleaned_url).first_or_create
+    if custom_key
+      scope.where(:url => cleaned_url, :unique_key => custom_key).first_or_create
+    else
+      scope.where(:url => cleaned_url).first_or_create
+    end
   end
 
   # return shortened url on success, nil on failure
-  def self.generate(orig_url, owner=nil)
+  def self.generate(orig_url, owner=nil, custom_key=nil)
     begin
-      generate!(orig_url, owner)
+      generate!(orig_url, owner, custom_key)
     rescue
       nil
     end

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -5,8 +5,9 @@ describe Shortener::ShortenedUrl do
   it { should belong_to :owner }
   it { should validate_presence_of :url }
 
+  let(:short_url) { Shortener::ShortenedUrl.generate!(long_url, owner, custom_key) }
+
   shared_examples_for "shortened url" do
-    let(:short_url) { Shortener::ShortenedUrl.generate!(long_url, owner) }
     it "should be shortened" do
       short_url.should_not be_nil
       short_url.url.should == expected_long_url
@@ -19,6 +20,7 @@ describe Shortener::ShortenedUrl do
     let(:long_url) { "http://www.doorkeeperhq.com/" }
     let(:expected_long_url) { long_url }
     let(:owner) { nil }
+    let(:custom_key) { nil }
     it_should_behave_like "shortened url"
   end
 
@@ -26,6 +28,7 @@ describe Shortener::ShortenedUrl do
     let(:long_url) { "www.doorkeeperhq.com" }
     let(:expected_long_url) { "http://www.doorkeeperhq.com/" }
     let(:owner) { nil }
+    let(:custom_key) { nil }
     it_should_behave_like "shortened url"
   end
 
@@ -33,6 +36,7 @@ describe Shortener::ShortenedUrl do
     let(:long_url) { "http://www.doorkeeper.jp/%E6%97%A5%E6%9C%AC%E8%AA%9E" }
     let(:expected_long_url) { long_url }
     let(:owner) { nil }
+    let(:custom_key) { nil }
     it_should_behave_like "shortened url"
   end
 
@@ -40,7 +44,19 @@ describe Shortener::ShortenedUrl do
     let(:long_url) { "http://www.doorkeeperhq.com/" }
     let(:expected_long_url) { long_url }
     let(:owner) { User.create }
+    let(:custom_key) { nil }
     it_should_behave_like "shortened url"
+  end
+
+  context "custom key" do
+    let(:long_url) { "http://www.doorkeeperhq.com/" }
+    let(:expected_long_url) { long_url }
+    let(:owner) { nil }
+    let(:custom_key) { 'custom' }
+
+    it "uses a unique key" do
+      short_url.unique_key.should == custom_key
+    end
   end
 
   context "existing shortened URL" do


### PR DESCRIPTION
This PR allows the unique key to be specified by the user, rather than having a randomly generated one produced. If no custom key is specified, the default behaviour occurs. 