### PR TITLE
Feature/has shortened urls specs

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+
+# user defined in dummy app, uses has_shortened_urls
+describe User do
+  it { should have_many :shortened_urls }
+
+  context 'shortened url created with owner' do
+    let (:user) { User.create }
+    let (:url) { Shortener::ShortenedUrl.generate("dealush.com", user) }
+    specify 'shorted_urls will contains the url' do
+      expect(user.shortened_urls).to include url
+      expect(user.shortened_urls.size).to be 1
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,9 +7,9 @@ describe User do
 
   context 'shortened url created with owner' do
     let (:user) { User.create }
-    let (:url) { Shortener::ShortenedUrl.generate("dealush.com", user) }
+    let (:shortened_url) { Shortener::ShortenedUrl.generate(Faker::Internet.url, owner: user) }
     specify 'shorted_urls will contains the url' do
-      expect(user.shortened_urls).to include url
+      expect(user.shortened_urls).to include shortened_url
       expect(user.shortened_urls.size).to be 1
     end
   end


### PR DESCRIPTION
Small PR to add a few specs around the has_shortened_urls ActiveRecordExtension.

This extension is applied to the User model in the dummy test app, and these specs
test that the has_shortened_urls extension is having the expected result.

replaces https://github.com/jpmcgrath/shortener/pull/27