### PR TITLE
Only generates a unique key if there isn't a value for unique key yet

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -81,7 +81,7 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   define_method CREATE_METHOD_NAME do
     count = 0
     begin
-      self.unique_key = generate_unique_key
+      self.unique_key = generate_unique_key if !self.unique_key
       super()
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid => err
       if (count +=1) < 5


### PR DESCRIPTION
Previously, if a custom_key parameter was passed into the generate method, it would get blown away by the method generating unique keys. This adds a check when generating the unique key to only do so if there isn't already a value present.