### PR TITLE
RSpec failure fixes and email interceptor regex update

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -81,7 +81,7 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   define_method CREATE_METHOD_NAME do
     count = 0
     begin
-      self.unique_key = generate_unique_key if !self.unique_key
+      self.unique_key = generate_unique_key
       super()
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid => err
       if (count +=1) < 5

--- a/lib/shortener/shorten_url_interceptor.rb
+++ b/lib/shortener/shorten_url_interceptor.rb
@@ -17,7 +17,7 @@ Usage:
                             'cloudfront\.net/' ].map {|r| Regexp.new(r) }
     DEFAULT_LENGTH_THRESHOLD = 20
 
-    URL_REGEX = /\b((https?):\/\/[\w\.-]+[\.]\w+)([-A-Z0-9+&@#\/%?=~_|$!:,.;]*[-A-Z0-9+&@#\/%=~_|$])?/i
+    URL_REGEX = /\b((https?):\/\/([\w\.-]+[\.]\w+)?)([-A-Z0-9+&@#\/%?=~_|$!:,.;]*[-A-Z0-9+&@#\/%=~_|$])?/i
     MIME_TYPES = %w(text/plain text/html application/xhtml+xml)
 
     def initialize(opts = {})

--- a/shortener.gemspec
+++ b/shortener.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 3.0.7"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", '~> 3.3.0'
-  s.add_development_dependency "shoulda-matchers"
+  s.add_development_dependency "shoulda-matchers", '~> 3'
   s.add_development_dependency "faker"
   s.add_development_dependency "byebug"
   s.executables = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -2,8 +2,8 @@
 require 'spec_helper'
 
 describe Shortener::ShortenedUrl, type: :model do
-  it { should belong_to :owner }
-  it { should validate_presence_of :url }
+  it { is_expected.to belong_to :owner }
+  it { is_expected.to validate_presence_of :url }
 
   describe '#generate!' do
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,8 +2,8 @@
 require 'spec_helper'
 
 # user defined in dummy app, uses has_shortened_urls
-describe User do
-  it { should have_many :shortened_urls }
+describe User, type: :model do
+  it { is_expected.to have_many(:shortened_urls) }
 
   context 'shortened url created with owner' do
     let (:user) { User.create }

--- a/spec/shortener/shorten_url_interceptor_spec.rb
+++ b/spec/shortener/shorten_url_interceptor_spec.rb
@@ -46,7 +46,8 @@ describe Shortener::ShortenUrlInterceptor do
     "http://client.doorkeeper.jp/events/124-",
     "http://client.doorkeeper.jp/events/124-title?auth_token=xabagangs",
     "http://client.doorkeeper.jp/events/124-%E4%F6%A0",
-    "https://www.test-site.com/"
+    "https://www.test-site.com/",
+    "https://test-suite.com/"
   ].each do |url|
     it_should_behave_like "shortens URL in text", url
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,5 +10,12 @@ require 'faker'
 
 Rails.backtrace_cleaner.remove_silencers!
 
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 # Run any available migration
 ActiveRecord::Migrator.migrate File.expand_path("../dummy/db/migrate/", __FILE__)


### PR DESCRIPTION
The main purpose is to catch URLs in the email interceptor that do not contain a subdomain.