### PR TITLE
Ruby 1.x Branch - Default Host + overridable char separator & number of attempts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "http://rubygems.org"
 
 # Specify any dependencies in the gemspec
 gemspec
+# gem 'byebug', platforms: [:mri_20, :mri_21, :mri_22]

--- a/README.rdoc
+++ b/README.rdoc
@@ -58,6 +58,12 @@ By default, when a unique key isn't matched the site is redirected to "/". You c
 ```
   Shortener.default_redirect = "http://www.someurl.com"
 ```
+
+Setting a default host:
+```
+  Shortener.default_host = "http://smrl.co"
+```
+If you have a separate short domain for short links, set the default host to that short domain. This will make the email interceptor & urls generated with the `short_url` helper use this domain.
 == Usage
 
 To generate a Shortened URL object for the URL "http://dealush.com" within your controller / models do the following:
@@ -73,6 +79,9 @@ To generate and display a shortened URL in your application use the helper metho
   short_url("dealush.com")
 
 This will generate a shortened URL. store it to the db and return a string representing the shortened URL.
+You can also use this helper with a Shortener::ShortenedUrl object, like so:
+
+  short_url(user.shortened_urls.last)
 
 === Shortened URLs with owner
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -51,31 +51,45 @@ Then add to your routes:
 The gem can be configured in a config/initializers/shortener.rb file.
 
 === Key length
-By default, the shortener will generate keys that are 5 characters long. You can change that by specifying the length of the key like so;
-```
+By default, the shortener will generate keys that are 5 characters long. You can change that by specifying the length of the key like so:
+
   Shortener.unique_key_length = 6
-```
 
 === Default redirect
 By default, when a unique key isn't matched the site is redirected to "/". You can change that by specifying a different url like so;
-```
+
   Shortener.default_redirect = "http://www.someurl.com"
-```
+
 
 === Default short url host
 Setting a default host:
-```
+
   Shortener.default_host = "http://smrl.co"
-```
-If you have a separate short domain for short links, set the default host to that short domain. This will make the email interceptor & urls generated with the `short_url` helper use this domain.
+
+If you have a separate short domain for short links, set the default host to that short domain. This will make the email interceptor &amp; urls generated with the `short_url` helper use this domain.
 
 === Alternative charset
 To set up a different charset for unique keys
 
-```
   Shortener::CHARSETS[:readable] = %w(a b c f g h i k n r s u x z)
   Shortener.charset = :readable
-```
+
+
+You could even generate keys as a string of words:
+
+  Shortener::CHARSETS[:fruits] = %w(apple banana kiwi fig grape cherry lemon lime orange melon peach pear papaya berry)
+  Shortener.charset = :fruits
+  Shortener.character_separator = "-"
+  Shortener.unique_key_length = 3
+  # this will generate keys like "apple-pear-banana"
+
+=== Attempt limit
+By default, shortener will attempt 5 times to generate a random unique key. If it fails 6 times, the `short_url` returns the original url instead of a short one.
+You can change the number of attempts:
+
+  Shortener::default_attempt_limit = 10
+
+If you have a small charset and/or short unique key, it's more likely to generate a duplicate key and have to try again.
 
 == Usage
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -50,20 +50,33 @@ Then add to your routes:
 == Configuration
 The gem can be configured in a config/initializers/shortener.rb file.
 
+=== Key length
 By default, the shortener will generate keys that are 5 characters long. You can change that by specifying the length of the key like so;
 ```
   Shortener.unique_key_length = 6
 ```
+
+=== Default redirect
 By default, when a unique key isn't matched the site is redirected to "/". You can change that by specifying a different url like so;
 ```
   Shortener.default_redirect = "http://www.someurl.com"
 ```
 
+=== Default short url host
 Setting a default host:
 ```
   Shortener.default_host = "http://smrl.co"
 ```
 If you have a separate short domain for short links, set the default host to that short domain. This will make the email interceptor & urls generated with the `short_url` helper use this domain.
+
+=== Alternative charset
+To set up a different charset for unique keys
+
+```
+  Shortener::CHARSETS[:readable] = %w(a b c f g h i k n r s u x z)
+  Shortener.charset = :readable
+```
+
 == Usage
 
 To generate a Shortened URL object for the URL "http://dealush.com" within your controller / models do the following:

--- a/README.rdoc
+++ b/README.rdoc
@@ -68,6 +68,27 @@ Setting a default host:
 
 If you have a separate short domain for short links, set the default host to that short domain. This will make the email interceptor &amp; urls generated with the `short_url` helper use this domain.
 
+Then when mounting the endpoint in your routes file, you may want to do something like this:
+
+  # config/routes.rb
+  class DomainConstraint
+    def initialize(*domains)
+      @domains = domains
+    end
+
+    def matches?(request)
+      @domains.include? request.host
+    end
+  end
+
+  MyApp::Application.routes.draw do
+    constraints DomainConstraint.new(Shortener.default_host) do
+      get '/:id' => "shortener/shortened_urls#show"
+      root to: redirect("https://www.looksharp.com")
+    end
+    # ...
+  end
+
 === Alternative charset
 To set up a different charset for unique keys
 

--- a/app/helpers/shortener/shortener_helper.rb
+++ b/app/helpers/shortener/shortener_helper.rb
@@ -2,7 +2,12 @@ module Shortener::ShortenerHelper
 
   # generate a url from a url string
   def short_url(url, owner=nil)
-    short_url = Shortener::ShortenedUrl.generate(url, owner)
+    short_url = if url.is_a? Shortener::ShortenedUrl
+                  url
+                else
+                  Shortener::ShortenedUrl.generate(url, owner)
+                end
+
     if short_url
       if host = Shortener.default_host.presence
         url_for(host: host, controller: :"shortener/shortened_urls", action: :show, id: short_url.unique_key, only_path: false)

--- a/app/helpers/shortener/shortener_helper.rb
+++ b/app/helpers/shortener/shortener_helper.rb
@@ -3,7 +3,15 @@ module Shortener::ShortenerHelper
   # generate a url from a url string
   def short_url(url, owner=nil)
     short_url = Shortener::ShortenedUrl.generate(url, owner)
-    short_url ? url_for(controller: :"shortener/shortened_urls", action: :show, id: short_url.unique_key, only_path: false) : url
+    if short_url
+      if host = Shortener.default_host.presence
+        url_for(host: host, controller: :"shortener/shortened_urls", action: :show, id: short_url.unique_key, only_path: false)
+      else
+        url_for(controller: :"shortener/shortened_urls", action: :show, id: short_url.unique_key, only_path: false)
+      end
+    else
+      url
+    end
   end
 
 end

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -68,7 +68,7 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
       self.unique_key = generate_unique_key
       super()
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid => err
-      if (count +=1) < 5
+      if (count +=1) < Shortener.default_attempt_limit
         logger.info("retrying with different unique key")
         retry
       else
@@ -83,7 +83,7 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   def generate_unique_key
     # not doing uppercase as url is case insensitive
     charset = ::Shortener.key_chars
-    (0...::Shortener.unique_key_length).map{ charset[rand(charset.size)] }.join
+    (0...::Shortener.unique_key_length).map{ charset[rand(charset.size)] }.join Shortener.character_separator
   end
 
 end

--- a/lib/shortener.rb
+++ b/lib/shortener.rb
@@ -27,6 +27,14 @@ module Shortener
   # default host for rendering shortened urls
   mattr_accessor :default_host
 
+  # default separator for characters
+  mattr_accessor :character_separator
+  self.character_separator = ""
+
+  # default attempts to generate unique key
+  mattr_accessor :default_attempt_limit
+  self.default_attempt_limit = 5
+
   def self.key_chars
     CHARSETS[charset]
   end

--- a/lib/shortener.rb
+++ b/lib/shortener.rb
@@ -24,6 +24,9 @@ module Shortener
   mattr_accessor :default_redirect
   self.default_redirect = '/'
 
+  # default host for rendering shortened urls
+  mattr_accessor :default_host
+
   def self.key_chars
     CHARSETS[charset]
   end

--- a/lib/shortener/shorten_url_interceptor.rb
+++ b/lib/shortener/shorten_url_interceptor.rb
@@ -52,9 +52,9 @@ Usage:
     end
 
     def self.infer_base_url
-      host = ActionMailer::Base.default_url_options[:host]
+      host = Shortener.default_host.presence || ActionMailer::Base.default_url_options[:host]
       if host.blank?
-        raise "Please supply :base_url for ShortenUrlInterceptor or define default_url_options for mailer"
+        raise "Please set Shortener.default_host, supply :base_url for ShortenUrlInterceptor or define default_url_options for mailer"
       else
         "http://#{host}/"
       end

--- a/shortener.gemspec
+++ b/shortener.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", '~> 3.3.0'
   s.add_development_dependency "shoulda-matchers", '~> 2.8.0'
   s.add_development_dependency "faker"
-  s.add_development_dependency "byebug"
   s.executables = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
   s.require_path = 'lib'
 end

--- a/shortener.gemspec
+++ b/shortener.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 3.0.7"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", '~> 3.3.0'
-  s.add_development_dependency "shoulda-matchers"
+  s.add_development_dependency "shoulda-matchers", '~> 2.8.0'
   s.add_development_dependency "faker"
   s.add_development_dependency "byebug"
   s.executables = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact

--- a/spec/helpers/shortener_helper_spec.rb
+++ b/spec/helpers/shortener_helper_spec.rb
@@ -23,5 +23,27 @@ describe Shortener::ShortenerHelper, type: :helper do
         expect(helper.short_url(destination)).to eq destination
       end
     end
+
+    context 'a short url passed in' do
+      let(:destination) { shortened_url }
+      let(:shortened_url) { instance_double('ShortenedUrl', unique_key: '12345') }
+
+      it "renders the url" do
+        expect(helper.short_url(destination)).to eq "http://test.host/12345"
+      end
+    end
+
+    context 'a default host set' do
+      let(:shortened_url) { instance_double('ShortenedUrl', unique_key: '12345') }
+
+      after {
+        Shortener.default_host = nil
+      }
+
+      it "shortens the url" do
+        Shortener.default_host = "http://foo.co"
+        expect(helper.short_url(destination)).to eq "http://foo.co/12345"
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ require 'shortener'
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require 'rspec/rails'
 require 'shoulda/matchers'
-require 'byebug'
 require 'faker'
 
 Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
Various enhancements to the latest ruby 1.x branch.
- allow users to specify a default host, so that short urls can be rendered on a different domain
- allow users to specify a character separator, in order to facilitate word-based keys ("apple-pear-banana")
- allow users to specify max attempt limit (since changing the # of characters & charset might result in more frequent duplicate keys)

Specs added for changes to the helper.
