### PR TITLE
Escape token extraction

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -60,7 +60,8 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
 
   def self.extract_token(token_str)
     # only use the leading valid characters
-    /^([#{Shortener.key_chars.join}]*).*/.match(token_str)[1]
+    # escape to ensure custom charsets with protected chars do not fail
+    /^([#{Regexp.escape(Shortener.key_chars.join)}]*).*/.match(token_str)[1]
   end
 
   def self.fetch_with_token(token: nil, additional_params: {})


### PR DESCRIPTION
This change allows monkey-patched charsets that contain regex protected characters to be used.

For example, the following initializer declares a charset that adds `-`. As a result, any short token including the `-` will currently fail token extraction.

*config/initializers/shortener.rb*
``` ruby
module Shortener
  send(:remove_const, :CHARSETS) if const_defined?(:CHARSETS)

  CHARSETS = {
    # Exclude vowels to preclude errant creation of words
    alphanumsafe: (('b'..'z').to_a + ('b'..'Z').to_a).reject { |l| l =~ /[eiou]/i } + (0..9).to_a + %w(- _),
  }
end

Shortener.default_redirect = Rails.application.secrets.web_host_share
Shortener.unique_key_length = 6
Shortener.charset = :alphanumsafe
```