### PR TITLE
Use unique_key as route param

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -99,6 +99,10 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
     end
   end
 
+  def to_param
+    unique_key
+  end
+
   private
 
   # the create method changed in rails 4...


### PR DESCRIPTION
For routes like this, `  get '/s/:id' => 'shortener/shortened_urls#show', :as => 'shortened_url'`, it'd be nice to be use url helpers like this: `shortened_url_path(shortened_url)`. As it stands, however, the only way to generate path is like this: `shortened_url_path(shortened_url.unique_key)`. 