### PR TITLE
Sets up default, global, shortening options

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -85,6 +85,16 @@ the upper and lower case charset, by including the following:
 
   Shortener.charset = :alphanumcase
 
+You can also specify global default parameters to be used with
+- <tt>Shortener::ShortenerHelper.short_url</tt>
+- <tt>Shortener::ShortenedUrl.generate</tt>
+- and <tt>Shortener::ShortenedUrl.generate!</tt>
+
+Any parameter explicitly passed to these functions takes precedence over the default parameters.
+
+  Shortener.default_shortening_params = { fresh: true,
+                                          url_options: { locale: nil}}
+
 == Usage
 
 To generate a Shortened URL object for the URL "http://example.com" within your controller / models do the following:

--- a/app/helpers/shortener/shortener_helper.rb
+++ b/app/helpers/shortener/shortener_helper.rb
@@ -1,16 +1,22 @@
 module Shortener::ShortenerHelper
 
   # generate a url from a url string
-  def short_url(url, owner: nil, custom_key: nil, expires_at: nil, fresh: false, url_options: {})
-    short_url = Shortener::ShortenedUrl.generate(url,
-                                                  owner:      owner,
-                                                  custom_key: custom_key,
-                                                  expires_at: expires_at,
-                                                  fresh:      fresh
-                                                )
+  def short_url(url, params={})
+    short_url = Shortener::ShortenedUrl.generate(url, params)
+
+    default_params = (Shortener.default_shortening_params || {})
+    url_options = Shortener.adhoc_shortening_params[:url_options]
+                    .merge(default_params[:url_options] || {})
+                    .merge(params[:url_options] || {})
 
     if short_url
-      options = { controller: :"shortener/shortened_urls", action: :show, id: short_url.unique_key, only_path: false }.merge(url_options)
+      options = {
+        controller: :"shortener/shortened_urls",
+        action: :show,
+        id: short_url.unique_key,
+        only_path: false
+      }.merge(url_options)
+
       url_for(options)
     else
       url

--- a/lib/shortener.rb
+++ b/lib/shortener.rb
@@ -28,6 +28,19 @@ module Shortener
   mattr_accessor :forbidden_keys
   self.forbidden_keys = []
 
+  # default shortening params
+  mattr_accessor :adhoc_shortening_params, instance_writer: false
+  self.adhoc_shortening_params = {
+    owner: nil,
+    custom_key: nil,
+    expires_at: nil,
+    fresh: false,
+    url_options: {}
+  }
+
+  mattr_accessor :default_shortening_params
+  self.default_shortening_params = {}
+
   def self.key_chars
     CHARSETS[charset]
   end

--- a/spec/helpers/shortener_helper_spec.rb
+++ b/spec/helpers/shortener_helper_spec.rb
@@ -4,10 +4,14 @@ require 'spec_helper'
 describe Shortener::ShortenerHelper, type: :helper do
   describe '#short_url' do
     let(:destination) { Faker::Internet.url }
+    let(:short_url) { double('ShortUrl', unique_key: 'knownkey') }
 
     context 'without user or custom key' do
       before do
-        expect(Shortener::ShortenedUrl).to receive(:generate).with(destination, owner: nil, custom_key: nil, expires_at: nil, fresh: false).and_return(shortened_url)
+        expect(Shortener::ShortenedUrl).to receive(:do_generate!)
+          .with(destination, owner: nil, custom_key: nil, expires_at: nil,
+                fresh: false)
+          .and_return(shortened_url)
       end
 
       context 'short url was generated' do
@@ -29,32 +33,128 @@ describe Shortener::ShortenerHelper, type: :helper do
 
     context 'with owner' do
       let(:owner) { double('User') }
-      it 'sends user to generate function' do
-        expect(Shortener::ShortenedUrl).to receive(:generate).with(destination, owner: owner, custom_key: nil, expires_at: nil, fresh: false)
+      it 'sends user to do_generate! function' do
+        expect(Shortener::ShortenedUrl).to receive(:do_generate!)
+          .with(destination, owner: owner, custom_key: nil, expires_at: nil,
+                fresh: false)
         helper.short_url(destination, owner: owner)
       end
     end
 
     context 'with custom_key' do
-      it 'sends custom key code to generate function' do
-        expect(Shortener::ShortenedUrl).to receive(:generate).with(destination, owner: nil, custom_key: 'custkey', expires_at: nil, fresh: false)
+      it 'sends custom key code to do_generate! function' do
+        expect(Shortener::ShortenedUrl).to receive(:do_generate!)
+          .with(destination, owner: nil, custom_key: 'custkey', expires_at: nil,
+                fresh: false)
         helper.short_url(destination, custom_key: 'custkey')
       end
     end
 
     context 'with expires_at' do
-      it 'sends custom key code to generate function' do
-        expect(Shortener::ShortenedUrl).to receive(:generate).with(destination, owner: nil, custom_key: nil, expires_at: 'testtime', fresh: false)
+      it 'sends custom key code to do_generate! function' do
+        expect(Shortener::ShortenedUrl).to receive(:do_generate!)
+          .with(destination, owner: nil, custom_key: nil,
+                expires_at: 'testtime', fresh: false)
         helper.short_url(destination, expires_at: 'testtime')
       end
     end
 
     context 'with url options for https and subdomain' do
-      let(:short_url) { double('ShortUrl', unique_key: 'knownkey') }
-      it 'sends custom key code to generate function' do
-        expect(Shortener::ShortenedUrl).to receive(:generate).and_return(short_url)
-        url = helper.short_url(destination, expires_at: 'testtime', url_options: { subdomain: 'foo', protocol: 'https'})
+      it 'sends custom key code to do_generate! function' do
+        expect(Shortener::ShortenedUrl).to receive(:do_generate!)
+          .and_return(short_url)
+        url = helper.short_url(destination, expires_at: 'testtime',
+                               url_options: { subdomain: 'foo',
+                                              protocol: 'https'})
         expect(url).to eq 'https://foo.test.host/knownkey'
+      end
+    end
+
+    describe '#generate using Shortener#default_shortening_params' do
+      let(:full_params) do
+        { owner: nil,
+          custom_key: 'default_custkey',
+          expires_at: 'default_testtime',
+          fresh: false,
+          url_options: { subdomain: 'bar', protocol: 'http'} }
+      end
+      let(:partial_params) do
+        { fresh: true,
+          url_options: { protocol: 'http',
+                         host: 'foobar'}  }
+      end
+      let(:adhoc_params) { Shortener.adhoc_shortening_params }
+
+      shared_examples_for 'URL shortening with default_shortening_params' do
+        let(:destination) { Faker::Internet.url }
+
+        before do
+          Shortener.default_shortening_params = default_shortening_params
+        end
+
+        it 'passes the right url_options to url_for function' do
+          expect(Shortener::ShortenedUrl)
+            .to receive(:do_generate!)
+            .and_return(short_url)
+          expect_any_instance_of(ActionView::RoutingUrlFor)
+            .to receive(:url_for)
+            .with hash_including(params_for_url_for)
+          if params_for_short_url
+            helper.short_url(destination, params_for_short_url)
+          else
+            helper.short_url(destination)
+          end
+        end
+      end
+
+      context 'with parameters passed to short_url' do
+        let(:passed_params) do
+          { owner: double('User', shortened_urls: destination),
+            custom_key: 'custkey',
+            expires_at: 'testtime',
+            fresh: true,
+            url_options: { subdomain: 'foo', protocol: 'https'} }
+        end
+
+        let(:default_shortening_params) { full_params }
+        let(:params_for_short_url)      { passed_params }
+        let(:params_for_url_for)        { passed_params[:url_options] }
+
+        it_behaves_like 'URL shortening with default_shortening_params'
+      end
+
+      context 'with no parameters passed to short_url function' do
+        let(:default_shortening_params) { full_params }
+        let(:params_for_short_url)      { nil }
+        let(:params_for_url_for)        { default_shortening_params[:url_options] }
+
+        it_behaves_like 'URL shortening with default_shortening_params'
+      end
+
+      context 'with parameters missing in call to short_url function' do
+        let(:default_shortening_params) { full_params }
+        let(:merged_params)             { default_shortening_params.deep_merge(partial_params) }
+        let(:params_for_short_url)      { partial_params }
+        let(:params_for_url_for)        { merged_params[:url_options] }
+
+        it_behaves_like 'URL shortening with default_shortening_params'
+      end
+
+      context 'with partial default parameters' do
+        let(:default_shortening_params) { partial_params }
+        let(:merged_params)             { adhoc_params.deep_merge(default_shortening_params) }
+        let(:params_for_short_url)      { nil }
+        let(:params_for_url_for)        { merged_params[:url_options] }
+
+        it_behaves_like 'URL shortening with default_shortening_params'
+      end
+
+      context 'with default parameters set to nil' do
+        let(:default_shortening_params) { nil }
+        let(:params_for_short_url)      { nil }
+        let(:params_for_url_for)        { adhoc_params[:url_options] }
+
+        it_behaves_like 'URL shortening with default_shortening_params'
       end
     end
   end


### PR DESCRIPTION
To be used with these functions :
- `Shortener::ShortenerHelper#short_url`
- `Shortener::ShortenedUrl#generate`
- and `Shortener::ShortenedUrl#generate!`

It allows the user to set default params to these functions via `Shortener.default_shortening_params`. Any parameter explicitly passed to these functions overrides the defaults.
