### PR TITLE
Fixes shortener in Rails 5

### DIFF
--- a/app/helpers/shortener/shortener_helper.rb
+++ b/app/helpers/shortener/shortener_helper.rb
@@ -10,7 +10,7 @@ module Shortener::ShortenerHelper
                                                 )
 
     if short_url
-      options = { controller: :"shortener/shortened_urls", action: :show, id: short_url.unique_key, only_path: false }.merge(url_options)
+      options = { controller: :"/shortener/shortened_urls", action: :show, id: short_url.unique_key, only_path: false }.merge(url_options)
       url_for(options)
     else
       url

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -107,7 +107,9 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
 
   # the create method changed in rails 4...
   CREATE_METHOD_NAME =
-    if Rails::VERSION::MAJOR >= 4
+    if Rails::VERSION::MAJOR >= 5
+      "_create_record"
+    elsif Rails::VERSION::MAJOR == 4
       # And again in 4.0.6/4.1.2
       if Rails::VERSION::MAJOR == 4 && (
           ((Rails::VERSION::MINOR == 0) && (Rails::VERSION::TINY < 6)) ||


### PR DESCRIPTION
Don't use create_record for Rails 5.  The current code path sometimes uses create_record instead of _create_record for Rails 5, but that fix was really only meant for certain versions of Rails 4.
