### PR TITLE
Support for Rails 5

### DIFF
--- a/app/controllers/shortener/shortened_urls_controller.rb
+++ b/app/controllers/shortener/shortened_urls_controller.rb
@@ -2,8 +2,13 @@ class Shortener::ShortenedUrlsController < ActionController::Base
 
   def show
     token = ::Shortener::ShortenedUrl.extract_token(params[:id])
-    url   = ::Shortener::ShortenedUrl.fetch_with_token(token: token, additional_params: params)
+    url   = ::Shortener::ShortenedUrl.fetch_with_token(token: token, additional_params: permitted_params)
     redirect_to url[:url], status: :moved_permanently
   end
 
+  private
+
+  def permitted_params
+    params.permit!.except(:controller, :action, :id)
+  end
 end

--- a/lib/shortener.rb
+++ b/lib/shortener.rb
@@ -1,4 +1,4 @@
-require "active_support/dependencies"
+require "active_support/all"
 
 module Shortener
 

--- a/shortener.gemspec
+++ b/shortener.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = "> 1.3.6"
   s.add_dependency "rails", ">= 3.0.7"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "rspec-rails", '~> 3.3.0'
+  s.add_development_dependency "rspec-rails", '~> 3.5.2'
   s.add_development_dependency "shoulda-matchers", '~> 3'
   s.add_development_dependency "faker"
   s.add_development_dependency "byebug"


### PR DESCRIPTION
This closes #74 and introduces support for Rails 5.

These are the minimum number of changes that I needed to make to make specs pass using Rails 5. Note that I didn't make any changes to _functional_ bits of the code - if you discount the addition of the `permitted_params` method.

I tried my branch against my Rails 5 app, and shortener is working again. More information on commits are available as commit descriptions.

I'm slightly confused by the fix offered in #73 because it wasn't required for my Rails 5 app.
