### PR TITLE
Fix migration template to add a category column instead of a label column

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,11 +40,11 @@ migration:
   end
 
 === v0.5.6 to v0.6.1
-v0.6.1 introduced the ability to category a shortened URL. The category value
-is stored in a string column in the database, which can be added to your schema with the following
+v0.6.1 introduced the ability to categorize a shortened URL. The category value
+is stored in a string column in the database, which must be added to your schema with the following
 migration:
 
-  bundle exec rails g migration add_category_to_shortened_url
+  bundle exec rails g migration add_category_to_shortened_url category:string:index
 
 
   class AddCategoryToShortenedUrl < ActiveRecord::Migration

--- a/lib/generators/shortener/templates/migration.rb
+++ b/lib/generators/shortener/templates/migration.rb
@@ -11,8 +11,8 @@ class CreateShortenedUrlsTable < ActiveRecord::Migration
       # the unique key
       t.string :unique_key, limit: 10, null: false
 
-      # a label to help categorize shortened urls
-      t.string :label, :string
+      # a category to help categorize shortened urls
+      t.string :category
 
       # how many times the link has been clicked
       t.integer :use_count, null: false, default: 0
@@ -28,6 +28,6 @@ class CreateShortenedUrlsTable < ActiveRecord::Migration
     add_index :shortened_urls, :unique_key, unique: true
     add_index :shortened_urls, :url
     add_index :shortened_urls, [:owner_id, :owner_type]
-    add_index :shortened_urls, :label
+    add_index :shortened_urls, :category
   end
 end

--- a/spec/dummy/db/migrate/20120213084304_create_shortened_urls_table.rb
+++ b/spec/dummy/db/migrate/20120213084304_create_shortened_urls_table.rb
@@ -3,7 +3,7 @@ class CreateShortenedUrlsTable < ActiveRecord::Migration
     create_table :shortened_urls do |t|
       # we can link this to a user for interesting things
       t.integer :owner_id
-      t.string :owner_type, limit: 40
+      t.string :owner_type, limit: 20
 
       # the real url that we will redirect to
       t.text :url, null: false


### PR DESCRIPTION
Also, made the upgrade instructions clearer, and fixed a discrepancy between the migration template and that in the specs.