### PR TITLE
Fix version constraint of voight_kampff

### DIFF
--- a/shortener.gemspec
+++ b/shortener.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "shortener"
   s.required_rubygems_version = "> 1.3.6"
   s.add_dependency "rails", ">= 3.0.7"
-  s.add_dependency "voight_kampff", '~>1.0.2'
+  s.add_dependency "voight_kampff", '~> 1.0'
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", '~> 3.3.0'
   s.add_development_dependency "shoulda-matchers", '~> 3'


### PR DESCRIPTION
`voight_kampff ~> 1.0.2` depends on rack 1, which makes the latest shortener cannot be included in rails 5 apps. 

```
Bundler could not find compatible versions for gem "rack":
  In Gemfile:
    rails (>= 5.0.0.1, ~> 5.0.0) was resolved to 5.0.0.1, which depends on
      actionpack (= 5.0.0.1) was resolved to 5.0.0.1, which depends on
-->     rack (~> 2.0)

    rails (>= 5.0.0.1, ~> 5.0.0) was resolved to 5.0.0.1, which depends on
      actionpack (= 5.0.0.1) was resolved to 5.0.0.1, which depends on
        rack-test (~> 0.6.3) was resolved to 0.6.3, which depends on
          rack (>= 1.0)

    sass-rails (~> 5.0) was resolved to 5.0.6, which depends on
      sprockets (< 4.0, >= 2.8) was resolved to 3.7.0, which depends on
        rack (< 3, > 1)

    shortener (= 0.6.2) was resolved to 0.6.2, which depends on
      voight_kampff (~> 1.0.2) was resolved to 1.0.2, which depends on
-->     rack (~> 1.6)
```