### PR TITLE
Update voight_kampff to 1.1

### DIFF
--- a/shortener.gemspec
+++ b/shortener.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "shortener"
   s.required_rubygems_version = "> 1.3.6"
   s.add_dependency "rails", ">= 3.0.7"
-  s.add_dependency "voight_kampff", '~> 1.0'
+  s.add_dependency "voight_kampff", '~> 1.1'
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", '~> 3.3.0'
   s.add_development_dependency "shoulda-matchers", '~> 3'

--- a/shortener.gemspec
+++ b/shortener.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email                     = [ "gems@jamespmcgrath.com", "michael@mobalean.com" ]
   s.homepage                  = "http://jamespmcgrath.com/projects/shortener"
   s.rubyforge_project         = "shortener"
-  s.required_rubygems_version = "> 1.3.6"
+  s.required_rubygems_version = "> 2.1.0"
   s.add_dependency "rails", ">= 3.0.7"
   s.add_dependency "voight_kampff", '~> 1.1'
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
voight_kampff `1.0` is holding rack below `2.0` which is holding me from updating to `Rails 5.0`

This update did not break any `spec` with `ruby 2.4.0`