### PR TITLE
Create charsets for ambiguous character removal

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -64,7 +64,6 @@ migration:
 
 === Future improvements:
 
-* There has not been an attempt to remove ambiguous characters (i.e. 1 l and capital i, or 0 and O etc.) from the unique key generated for the link. This means people might copy the link incorrectly if copying the link by hand;
 * The system could pre-generate unique keys in advance, avoiding the database penalty when checking that a newly generated key is unique;
 * The system could store the shortened URL if the url is to be continually rendered;
 
@@ -99,6 +98,9 @@ By default, Shortener will generate unique keys using numbers and lowercase a-z.
 the upper and lower case charset, by including the following:
 
   Shortener.charset = :alphanumcase
+
+The `:alphanum_no_ambiguous` and `:alphanumcase_no_ambiguous` charsets are also available if you desire to avoid ambiguous characters
+('i', 'o', 'l', 'I', 'O', '0', '1') in the unique keys.
 
 == Usage
 

--- a/lib/shortener.rb
+++ b/lib/shortener.rb
@@ -5,9 +5,14 @@ module Shortener
   autoload :ActiveRecordExtension, "shortener/active_record_extension"
   autoload :ShortenUrlInterceptor, "shortener/shorten_url_interceptor"
 
+  AMBIGUOUS_CHARACTERS = ['i', 'o', 'l', 'I', 'O', '0', '1'].freeze
+
   CHARSETS = {
-    alphanum: ('a'..'z').to_a + (0..9).to_a,
-    alphanumcase: ('a'..'z').to_a + ('A'..'Z').to_a + (0..9).to_a
+    alphanum: ('a'..'z').to_a + (0..9).map(&:to_s).to_a,
+    alphanumcase: ('a'..'z').to_a + ('A'..'Z').to_a + (0..9).map(&:to_s).to_a,
+    alphanum_no_ambiguous: ('a'..'z').to_a + (0..9).map(&:to_s).to_a - AMBIGUOUS_CHARACTERS,
+    alphanumcase_no_ambiguous:
+      ('a'..'z').to_a + ('A'..'Z').to_a + (0..9).map(&:to_s).to_a - AMBIGUOUS_CHARACTERS
   }
 
   # default key length: 5 characters
@@ -15,8 +20,10 @@ module Shortener
   self.unique_key_length = 5
 
   # character set to chose from:
-  #  :alphanum     - a-z0-9     -  has about 60 million possible combos
-  #  :alphanumcase - a-zA-Z0-9  -  has about 900 million possible combos
+  #  :alphanum     - a-z0-9
+  #  :alphanumcase - a-zA-Z0-9
+  #  :alphanum_no_ambiguous - alphanum without ambiguous characters
+  #  :alphanumcase_no_ambiguous - alphanumcase without ambiguous characters
   mattr_accessor :charset
   self.charset = :alphanum
 


### PR DESCRIPTION
Introduces the `:alphanum_no_ambiguous` and `:alphanumcase_no_ambiguous` charsets.