### PR TITLE
Pin rspec-rails dependency to 3.4.4 or later

### DIFF
--- a/shortener.gemspec
+++ b/shortener.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 3.0.7"
   s.add_dependency "voight_kampff", '~> 1.0'
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "rspec-rails", '~> 3.3.0'
+  s.add_development_dependency "rspec-rails", ">= 3.4.4"
   s.add_development_dependency "shoulda-matchers", '~> 3'
   s.add_development_dependency "faker"
   s.add_development_dependency "byebug"


### PR DESCRIPTION
As noted on [StackOverflow](https://stackoverflow.com/questions/35893584), recent versions of `Rake` remove the `last_comment` method which pre-3.4.4 versions of `rspec-core` use (in turn used by pre-3.4.4 versions of `rspec-rails`). Removing the pin on the 3.3.0 version eliminates the `last_comment` error.

Pinned to 3.3.0
```
$ bundle exec rake
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x007fb57b0acd90>
/usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.3.2/lib/rspec/core/rake_task.rb:82:in `define'
/usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.3.2/lib/rspec/core/rake_task.rb:62:in `initialize'
/Users/asherkach/Programs/shortener/Rakefile:7:in `new'
/Users/asherkach/Programs/shortener/Rakefile:7:in `<top (required)>'
/usr/local/lib/ruby/gems/2.4.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
(See full trace by running task with --trace)
```

Pinned to 3.4.4 or later:
```
$ bundle exec rake
/usr/local/Cellar/ruby/2.4.1_1/bin/ruby -I/usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib:/usr/local/lib/ruby/gems/2.4.0/gems/rspec-support-3.6.0/lib /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
DEPRECATION WARNING: You didn't set `secret_key_base`. Read the upgrade documentation to learn more about this new config option. (called from validate_secret_key_config! at /usr/local/lib/ruby/gems/2.4.0/gems/railties-4.2.9/lib/rails/application.rb:530)
................................................................................................................

Finished in 11.34 seconds (files took 1.09 seconds to load)
112 examples, 0 failures
```