### PR TITLE
Use ActionController::Metal

### DIFF
--- a/app/controllers/shortener/shortened_urls_controller.rb
+++ b/app/controllers/shortener/shortened_urls_controller.rb
@@ -1,4 +1,8 @@
-class Shortener::ShortenedUrlsController < ActionController::Base
+class Shortener::ShortenedUrlsController < ActionController::Metal
+  include ActionController::StrongParameters
+  include ActionController::Redirecting
+  include ActionController::Instrumentation
+  include Rails.application.routes.url_helpers
   include Shortener
 
   def show


### PR DESCRIPTION
Prevents common ActionController::Base extensions from getting in the way of this being as fast an action as possible.

It’s common in apps to pollute ActionController::Base with before_filters that we don’t have any interest in.