### PR TITLE
adding optional option for owner relationship

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source "http://rubygems.org"
 
 # Specify any dependencies in the gemspec
 gemspec
+
+group :test do
+  gem 'shoulda-matchers', git: 'https://github.com/thoughtbot/shoulda-matchers.git', ref: 'c0960bd72dd41c4e9bd8b4375254f539776bfe95'
+end

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -7,7 +7,7 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   before_create :generate_unique_key
 
   # allows the shortened link to be associated with a user
-  belongs_to :owner, polymorphic: true
+  belongs_to :owner, polymorphic: true, optional: true
 
   # exclude records in which expiration time is set and expiration time is greater than current time
   scope :unexpired, -> { where(arel_table[:expires_at].eq(nil).or(arel_table[:expires_at].gt(::Time.current.to_s(:db)))) }

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe Shortener::ShortenedUrl, type: :model do
-  it { is_expected.to belong_to :owner }
+  it { is_expected.to belong_to(:owner).optional }
   it { is_expected.to validate_presence_of :url }
 
   describe '#generate!' do


### PR DESCRIPTION
Rails 5 now makes belongs_to relationships required by default, in order to avoid this an optional parameter set to true should be used on the relationship definition