### PR TITLE
Allow custom charsets

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -100,6 +100,10 @@ By default, Shortener will generate unique keys using numbers and lowercase a-z.
 the upper and lower case charset, by including the following:
 
   Shortener.charset = :alphanumcase
+  
+If you want to use a custom charset, you can create your own combination by creating an array of possible values, such as allowing underscore and dashes:
+
+  Shortener.charset = ("a".."z").to_a + (0..9).to_a + ["-", "_"]
 
 == Usage
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -105,6 +105,10 @@ If you want to use a custom charset, you can create your own combination by crea
 
   Shortener.charset = ("a".."z").to_a + (0..9).to_a + ["-", "_"]
 
+If you want to use a custom charset, you can create your own combination by creating an array of possible values, such as allowing underscore and dashes:
+
+  Shortener.charset = ("a".."z").to_a + (0..9).to_a + ["-", "_"]
+
 == Usage
 
 To generate a Shortened URL object for the URL "http://example.com" within your controller / models do the following:

--- a/lib/shortener.rb
+++ b/lib/shortener.rb
@@ -19,8 +19,9 @@ module Shortener
   self.unique_key_length = 5
 
   # character set to chose from:
-  #  :alphanum     - a-z0-9     -  has about 60 million possible combos
-  #  :alphanumcase - a-zA-Z0-9  -  has about 900 million possible combos
+  #  :alphanum     // a-z0-9                                       ## has about 60 million possible combos
+  #  :alphanumcase // a-zA-Z0-9                                    ## has about 900 million possible combos
+  #  ("a".."z").to_a + ("A".."Z").to_a + (0..9).to_a + ["-", "_"]  ## define a custom set
   mattr_accessor :charset
   self.charset = :alphanum
 

--- a/lib/shortener.rb
+++ b/lib/shortener.rb
@@ -38,7 +38,7 @@ module Shortener
 
 
   def self.key_chars
-    CHARSETS[charset]
+    charset.is_a?(Symbol) ? CHARSETS[charset] : charset
   end
 end
 

--- a/spec/controllers/shortened_urls_controller_spec.rb
+++ b/spec/controllers/shortened_urls_controller_spec.rb
@@ -132,6 +132,21 @@ describe Shortener::ShortenedUrlsController, type: :controller do
         end
       end
 
+      context "custom charset set" do
+        before do
+          Shortener::ShortenedUrl.delete_all
+          Shortener.charset = ("a".."z").to_a + ("A".."Z").to_a + (0..9).to_a + ["-", "_"]
+        end
+
+        context 'key with valid characters' do
+          let(:key) { "cust-Key_123" }
+          let(:custom_url) { Shortener::ShortenedUrl.generate(Faker::Internet.url, custom_key: key) }
+          it 'allows if in custom charset' do
+            expect(custom_url.unique_key).to eq key
+          end      
+        end       
+      end
+
       context 'expired code' do
         let(:expired_url) { Shortener::ShortenedUrl.generate(Faker::Internet.url, expires_at: 1.hour.ago) }
         describe "GET show with expired code" do


### PR DESCRIPTION
This would allow you to easily override the charset with whatever you wanted to allow, like allowing dashes for instance:

In initializers/shortener.rb you could then have something like:
```
Shortener.charset = ("a".."z").to_a + ("A".."Z").to_a + (0..9).to_a + ["-", "_"]
```