### PR TITLE
Move retry block outside of ActiveRecord's persistence life cycle

### DIFF
--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -133,7 +133,6 @@ describe Shortener::ShortenedUrl, type: :model do
       context "duplicate unique key" do
         let(:duplicate_key) { 'ABCDEF' }
         it 'should try until it finds a non-dup key' do
-          Shortener::ShortenedUrl.where(unique_key: duplicate_key).delete_all
           Shortener::ShortenedUrl.create!(url: Faker::Internet.url, custom_key: duplicate_key)
           short_url = Shortener::ShortenedUrl.generate!(Faker::Internet.url, custom_key: duplicate_key)
           expect(short_url).not_to be_nil
@@ -151,7 +150,6 @@ describe Shortener::ShortenedUrl, type: :model do
           end
 
           it 'raises the non unique error' do
-            Shortener::ShortenedUrl.where(unique_key: duplicate_key).delete_all
             Shortener::ShortenedUrl.create!(url: Faker::Internet.url, custom_key: duplicate_key)
             expect {
               Shortener::ShortenedUrl.create!(url: Faker::Internet.url, custom_key: duplicate_key)

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -121,6 +121,15 @@ describe Shortener::ShortenedUrl, type: :model do
         end
       end
 
+      context 'custom_key not specified' do
+        it 'generates a new one using the option `key_chars`' do
+          allow(Shortener).to receive(:key_chars) { 'Z' }
+          short_url = Shortener::ShortenedUrl.generate!(Faker::Internet.url, custom_key: nil)
+          expect(short_url).to be_persisted
+          expect(short_url.unique_key).to eq('Z' * Shortener.unique_key_length)
+        end
+      end
+
       context "duplicate unique key" do
         let(:duplicate_key) { 'ABCDEF' }
         it 'should try until it finds a non-dup key' do

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -126,7 +126,7 @@ describe Shortener::ShortenedUrl, type: :model do
         it 'should try until it finds a non-dup key' do
           Shortener::ShortenedUrl.where(unique_key: duplicate_key).delete_all
           Shortener::ShortenedUrl.create!(url: Faker::Internet.url, custom_key: duplicate_key)
-          short_url = Shortener::ShortenedUrl.create!(url: Faker::Internet.url, custom_key: duplicate_key)
+          short_url = Shortener::ShortenedUrl.generate!(Faker::Internet.url, custom_key: duplicate_key)
           expect(short_url).not_to be_nil
           expect(short_url.unique_key).not_to be_nil
           expect(short_url.unique_key).not_to eq duplicate_key

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,3 +23,7 @@ if ActiveRecord::Migrator.respond_to?(:migrate)
 else
   ActiveRecord::MigrationContext.new(File.expand_path("../dummy/db/migrate/", __FILE__)).migrate
 end
+
+RSpec.configure do |config|
+  config.use_transactional_fixtures = true
+end


### PR DESCRIPTION
Previously we were catching `ActiveRecord::RecordNotUnique` error in the
`around_create` callback of `ShortenedUrl`. This means the retry was called
inside transaction. It worked fine for MySQL and Sqlite but
Postgres transactions needs to be ROLLBACK'ed on errors.

This is a breaking change if someone expects that
`Shortener::ShortenedUrl::create!` will handle the collisions on `unique_key`.
The collisions will only be handled by `Shortener::ShortenedUrl::generate!`.