### PR TITLE
Fix token uniqueness, closes: #108, #106

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -131,8 +131,10 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   end
 
   def generate_unique_key(retries = Shortener.persist_retries)
-    self.unique_key = custom_key || self.class.unique_key_candidate
-    self.custom_key = nil
+    begin
+      self.unique_key = custom_key || self.class.unique_key_candidate
+      self.custom_key = nil
+    end while self.class.unscoped.exists?(unique_key: unique_key)
 
     yield
   rescue ActiveRecord::RecordNotUnique

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -123,31 +123,48 @@ describe Shortener::ShortenedUrl, type: :model do
 
       context "duplicate unique key" do
         let(:duplicate_key) { 'ABCDEF' }
-        it 'should try until it finds a non-dup key' do
+        context 'without retry' do
+          around do |spec|
+            tries = Shortener.persist_retries
+            Shortener.persist_retries = 0
+            spec.run
+            Shortener.persist_retries = tries
+          end
+
+          it 'finds a non-dup key' do
+            Shortener::ShortenedUrl.where(unique_key: duplicate_key).delete_all
+            Shortener::ShortenedUrl.create!(url: Faker::Internet.url, custom_key: duplicate_key)
+            short_url = Shortener::ShortenedUrl.create!(url: Faker::Internet.url, custom_key: duplicate_key)
+            expect(short_url).not_to be_nil
+            expect(short_url.unique_key).not_to be_nil
+            expect(short_url.unique_key).not_to eq duplicate_key
+          end
+
+          it 'unscoped query to finds a non-dup key' do
+            Shortener::ShortenedUrl.where(unique_key: duplicate_key).delete_all
+            Shortener::ShortenedUrl.create!(url: Faker::Internet.url, custom_key: duplicate_key)
+            short_url = Shortener::ShortenedUrl.where(
+              url: Faker::Internet.url, category: :test
+            ).create!(url: Faker::Internet.url, custom_key: duplicate_key)
+            expect(short_url).not_to be_nil
+            expect(short_url.unique_key).not_to be_nil
+            expect(short_url.unique_key).not_to eq duplicate_key
+          end
+        end
+
+        it 'use retry in case with DB unique constraint exception' do
           Shortener::ShortenedUrl.where(unique_key: duplicate_key).delete_all
           Shortener::ShortenedUrl.create!(url: Faker::Internet.url, custom_key: duplicate_key)
+
+          query = double
+          query.stub(:exists?).and_return(false)
+          allow(Shortener::ShortenedUrl).to receive(:unscoped).and_return(query).once
+          allow(Shortener::ShortenedUrl).to receive(:unscoped).and_call_original
+
           short_url = Shortener::ShortenedUrl.create!(url: Faker::Internet.url, custom_key: duplicate_key)
           expect(short_url).not_to be_nil
           expect(short_url.unique_key).not_to be_nil
           expect(short_url.unique_key).not_to eq duplicate_key
-        end
-
-        context 'the persist_retries is set to 1' do
-          around do |example|
-            tries = Shortener.persist_retries
-
-            Shortener.persist_retries = 0
-            example.run
-            Shortener.persist_retries = tries
-          end
-
-          it 'raises the non unique error' do
-            Shortener::ShortenedUrl.where(unique_key: duplicate_key).delete_all
-            Shortener::ShortenedUrl.create!(url: Faker::Internet.url, custom_key: duplicate_key)
-            expect {
-              Shortener::ShortenedUrl.create!(url: Faker::Internet.url, custom_key: duplicate_key)
-            }.to raise_error(ActiveRecord::RecordNotUnique)
-          end
         end
       end
     end


### PR DESCRIPTION
previously fixed in #106 via handling `ActiveRecord::RecordNotUnique` with expectation to protect from race conditions, but there was more general problem than race conditions, uniqueness of token was checked by `exists?` query with wrong scope as result same token with different category was accepted as unique, relate issue #108 

so currently `ActiveRecord::RecordNotUnique` exception is handled inside transaction as result retry has no effect when PostgreSQL is used, as solution I have fixed `exists?` query which was used before #106 so it should properly check token uniqueness without raising exception, what about race conditions they will continue to be handled with rescue and DBs which allow to do it in same transaction as before
