### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -150,9 +150,11 @@ And to access those URLs:
 
 === Shortened URLs with custom unique key
 
-You can pass in your own key when generating a shortened URL. This should be unique.
+You can pass in your own key when generating a shortened URL. This should be unique.  
 
-  Shortener::ShortenedUrl.generate("example.com", owner: user, custom_key: "my-key")
+*Important:* Custom keys can't contain characters other than those defined in *Shortener.charset*. Default is numbers and lowercase a-z (See *Configuration*).
+
+  Shortener::ShortenedUrl.generate("example.com", owner: user, custom_key: "mykey")
 
   short_url("http://example.com", custom_key: 'yourkey')
 


### PR DESCRIPTION
When generating a custom key, it is not obvious that the key has to also adhere to the configured Charset. If not the key will be truncated when passed through the `extract_token` method of the model.

E.g.: 
- Charset is default :alphanum
- "my-key" becomes "my" because "-" is not a legal character
