### PR TITLE
Remove user index from tables

### DIFF
--- a/lib/generators/shortener/templates/migration.rb
+++ b/lib/generators/shortener/templates/migration.rb
@@ -26,7 +26,6 @@ class CreateShortenedUrlsTable < ActiveRecord::Migration[4.2]
     # we will lookup the links in the db by key, urls and owners.
     # also make sure the unique keys are actually unique
     add_index :shortened_urls, :unique_key, unique: true
-    add_index :shortened_urls, :url, length: 2083
     add_index :shortened_urls, [:owner_id, :owner_type]
     add_index :shortened_urls, :category
   end

--- a/spec/controllers/shortened_urls_controller_spec.rb
+++ b/spec/controllers/shortened_urls_controller_spec.rb
@@ -143,12 +143,13 @@ describe Shortener::ShortenedUrlsController, type: :controller do
           let(:custom_url) { Shortener::ShortenedUrl.generate(Faker::Internet.url, custom_key: key) }
           it 'allows if in custom charset' do
             expect(custom_url.unique_key).to eq key
-          end      
-        end       
+          end
+        end
       end
 
       context 'expired code' do
         let(:expired_url) { Shortener::ShortenedUrl.generate(Faker::Internet.url, expires_at: 1.hour.ago) }
+
         describe "GET show with expired code" do
           let(:key) { expired_url.unique_key }
           it 'redirects to the default url' do

--- a/spec/dummy/db/migrate/20120213084304_create_shortened_urls_table.rb
+++ b/spec/dummy/db/migrate/20120213084304_create_shortened_urls_table.rb
@@ -6,7 +6,7 @@ class CreateShortenedUrlsTable < ActiveRecord::Migration[4.2]
       t.string :owner_type, limit: 20
 
       # the real url that we will redirect to
-      t.text :url, null: false
+      t.text :url, null: false, length: 2083
 
       # the unique key
       t.string :unique_key, limit: 10, null: false
@@ -26,7 +26,6 @@ class CreateShortenedUrlsTable < ActiveRecord::Migration[4.2]
     # we will lookup the links in the db by key, urls and owners.
     # also make sure the unique keys are actually unique
     add_index :shortened_urls, :unique_key, unique: true
-    add_index :shortened_urls, :url
     add_index :shortened_urls, [:owner_id, :owner_type]
     add_index :shortened_urls, :category
   end

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -96,6 +96,18 @@ describe Shortener::ShortenedUrl, type: :model do
                 expect(new_url.category).to eq 'test'
               end
             end
+
+            context 'original url without category' do
+              let!(:existing_shortened_url) { Shortener::ShortenedUrl.generate!(url) }
+              it 'returns the same shortened link record' do
+                new_url = Shortener::ShortenedUrl.generate!(url, category: 'test')
+                expect(new_url).not_to eq existing_shortened_url
+                expect(new_url.category).to eq 'test'
+
+                lastest_url = Shortener::ShortenedUrl.generate!(url, category: 'test')
+                expect(lastest_url).to eq new_url
+              end
+            end
           end
         end
 

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -167,6 +167,19 @@ describe Shortener::ShortenedUrl, type: :model do
           expect(short_url.unique_key).not_to eq duplicate_key
         end
       end
+
+      context 'same url is not existed' do
+        it 'returns the same key' do
+          existing_shortened_url.destroy
+
+          new_url = Shortener::ShortenedUrl.generate!(existing_shortened_url.url)
+          expect(new_url.unique_key).to eq existing_shortened_url.unique_key
+
+          new_url.destroy
+          new_url = Shortener::ShortenedUrl.generate!(url, fresh: true)
+          expect(new_url.unique_key).to eq existing_shortened_url.unique_key
+        end
+      end
     end
 
     context "existing shortened URL with relative path" do
@@ -335,22 +348,22 @@ describe Shortener::ShortenedUrl, type: :model do
   describe '#get_unique_key' do
     let(:url) { Faker::Internet.url }
 
-    it 'should get certain value with same urls' do
+    it 'returns certain value with same urls' do
       key = Shortener::ShortenedUrl.get_unique_key(url)
       expect(Shortener::ShortenedUrl.get_unique_key(url)).to eq key
     end
 
-    it 'should get different value with different urls' do
+    it 'returns different value with different urls' do
       key = Shortener::ShortenedUrl.get_unique_key(url)
       expect(url).not_to eq key
     end
 
-    it 'should get different value with same urls by random' do
+    it 'returns different value with same urls by random' do
       key = Shortener::ShortenedUrl.get_unique_key(url)
       expect(Shortener::ShortenedUrl.get_unique_key(url, random: true)).not_to eq key
     end
 
-    it 'should get certain length' do
+    it 'returns certain length' do
       expect(Shortener::ShortenedUrl.get_unique_key(url, length: 4).size).to eq 4
     end
   end

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -331,4 +331,27 @@ describe Shortener::ShortenedUrl, type: :model do
       end
     end
   end
+
+  describe '#get_unique_key' do
+    let(:url) { Faker::Internet.url }
+
+    it 'should get certain value with same urls' do
+      key = Shortener::ShortenedUrl.get_unique_key(url)
+      expect(Shortener::ShortenedUrl.get_unique_key(url)).to eq key
+    end
+
+    it 'should get different value with different urls' do
+      key = Shortener::ShortenedUrl.get_unique_key(url)
+      expect(url).not_to eq key
+    end
+
+    it 'should get different value with same urls by random' do
+      key = Shortener::ShortenedUrl.get_unique_key(url)
+      expect(Shortener::ShortenedUrl.get_unique_key(url, random: true)).not_to eq key
+    end
+
+    it 'should get certain length' do
+      expect(Shortener::ShortenedUrl.get_unique_key(url, length: 4).size).to eq 4
+    end
+  end
 end

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -345,26 +345,26 @@ describe Shortener::ShortenedUrl, type: :model do
     end
   end
 
-  describe '#get_unique_key' do
+  describe '#unique_key_candidate' do
     let(:url) { Faker::Internet.url }
 
     it 'returns certain value with same urls' do
-      key = Shortener::ShortenedUrl.get_unique_key(url)
-      expect(Shortener::ShortenedUrl.get_unique_key(url)).to eq key
+      key = Shortener::ShortenedUrl.unique_key_candidate(url: url)
+      expect(Shortener::ShortenedUrl.unique_key_candidate(url: url)).to eq key
     end
 
     it 'returns different value with different urls' do
-      key = Shortener::ShortenedUrl.get_unique_key(url)
+      key = Shortener::ShortenedUrl.unique_key_candidate(url: url)
       expect(url).not_to eq key
     end
 
     it 'returns different value with same urls by random' do
-      key = Shortener::ShortenedUrl.get_unique_key(url)
-      expect(Shortener::ShortenedUrl.get_unique_key(url, random: true)).not_to eq key
+      key = Shortener::ShortenedUrl.unique_key_candidate(url: url)
+      expect(Shortener::ShortenedUrl.unique_key_candidate(url: url, random: true)).not_to eq key
     end
 
     it 'returns certain length' do
-      expect(Shortener::ShortenedUrl.get_unique_key(url, length: 4).size).to eq 4
+      expect(Shortener::ShortenedUrl.unique_key_candidate(url: url, length: 4).size).to eq 4
     end
   end
 end


### PR DESCRIPTION
Fixes #120

1. remove user index from shortened_urls

2. add handler for generating certain key by url

3. while generating new record, find existing record by unique_key

4. while generating freshly, skip existing record

5. expose Shortener::ShortenedUrl::unique_key_candidate to children for custom unique key, for example

```ruby
# shortened_url.rb
class ShortenedUrl < Shortener::ShortenedUrl
  class << self
    def unique_key_candidate(url: nil, random: false, length: Shortener.unique_key_length)
      token = super(url: url, random: random, length: length - 1)
      "#{token}#{safe_code(token)}".freeze
    end

    def valid_token?(token)
      token.size == Shortener.unique_key_length && token.last == safe_code(token) rescue false
    end
  end
end
```

thanks for review :)