### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/shortener.gemspec
+++ b/shortener.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.authors                   = [ "James P. McGrath", "Michael Reinsch" ]
   s.email                     = [ "gems@jamespmcgrath.com", "michael@mobalean.com" ]
   s.homepage                  = "http://jamespmcgrath.com/projects/shortener"
-  s.rubyforge_project         = "shortener"
   s.required_rubygems_version = "> 2.1.0"
 
   s.add_dependency "voight_kampff", '~> 1.1.2'


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436