### PR TITLE
CI: 2.5, 2.6, 2.7 run Rails 6.0 gemfile, too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,16 @@ rvm:
 
 matrix:
   fast_finish: true
+  include:
+    - rvm: 2.5
+      gemfile: gemfiles/rails_6.0.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/rails_6.0.gemfile
+    - rvm: 2.7
+      gemfile: gemfiles/rails_6.0.gemfile
 
 gemfile:
   - gemfiles/rails_4.gemfile
   - gemfiles/rails_5.0.gemfile
   - gemfiles/rails_5.1.gemfile
   - gemfiles/rails_5.2.gemfile
-  - gemfiles/rails_6.0.gemfile


### PR DESCRIPTION
This PR modifies the CI matrix, to let Rails 6 run on platforms it supports.

Looks like this in the matrix:

<img width="1274" alt="bild" src="https://user-images.githubusercontent.com/211/80490325-7a9a7f80-8961-11ea-8d4c-67aa961752f0.png">


See #130 