### PR TITLE
Fixes to get CI to be green again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: ruby
 
 rvm:
-  - 2.2.10
+  - 2.2
   - 2.3
   - 2.4
   - 2.5
   - 2.6
   - 2.7
-
-matrix:
-  fast_finish: true
 
 gemfile:
   - gemfiles/rails_4.gemfile
@@ -17,3 +14,19 @@ gemfile:
   - gemfiles/rails_5.1.gemfile
   - gemfiles/rails_5.2.gemfile
   - gemfiles/rails_6.0.gemfile
+
+jobs:
+  fast_finish: true
+  exclude:
+  - rvm: 2.6
+    gemfile: gemfiles/rails_4.gemfile
+  - rvm: 2.7
+    gemfile: gemfiles/rails_4.gemfile
+  - rvm: 2.2
+    gemfile: gemfiles/rails_5.2.gemfile
+  - rvm: 2.2
+    gemfile: gemfiles/rails_6.0.gemfile
+  - rvm: 2.3
+    gemfile: gemfiles/rails_6.0.gemfile
+  - rvm: 2.4
+    gemfile: gemfiles/rails_6.0.gemfile

--- a/spec/controllers/shortened_urls_controller_spec.rb
+++ b/spec/controllers/shortened_urls_controller_spec.rb
@@ -138,13 +138,17 @@ describe Shortener::ShortenedUrlsController, type: :controller do
           Shortener.charset = ("a".."z").to_a + ("A".."Z").to_a + (0..9).to_a + ["-", "_"]
         end
 
+        after do
+          Shortener.charset = :alphanum
+        end
+
         context 'key with valid characters' do
           let(:key) { "cust-Key_123" }
           let(:custom_url) { Shortener::ShortenedUrl.generate(Faker::Internet.url, custom_key: key) }
           it 'allows if in custom charset' do
             expect(custom_url.unique_key).to eq key
-          end      
-        end       
+          end
+        end
       end
 
       context 'expired code' do


### PR DESCRIPTION
This does 2 things:
- It fixes the spec which I added in the rails6 upgrade to always pass
- It excludes impossible ruby / rails versions from the build matrix