### PR TITLE
Allow to configure different database for shortened_urls table

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -256,6 +256,18 @@ If you want more things to happen when a user accesses one of your short urls, y
 
   *note:* If no shortened URL is found, the url will be `default_redirect` or `/`
 
+=== Configuring a different database for shortened_urls table
+
+You can store a `shortened_urls` table in another database and connecting to it by creating a initializer with the following:
+
+```ruby
+ActiveSupport.on_load(:shortener_record) do
+  connects_to(database: { writing: :dbname, reading: :dbname_replica })
+end
+```
+
+**Note:** Please, replace `dbname` and `dbname_replica` to match your database configuration.
+
 == Origins
 
 For a bit of backstory to Shortener see this {blog post}[http://jamespmcgrath.com/a-simple-link-shortener-in-rails/].

--- a/app/models/shortener/record.rb
+++ b/app/models/shortener/record.rb
@@ -1,0 +1,5 @@
+class Shortener::Record < ActiveRecord::Base #:nodoc:
+  self.abstract_class = true
+end
+
+ActiveSupport.run_load_hooks :shortener_record, Shortener::Record

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -1,4 +1,4 @@
-class Shortener::ShortenedUrl < ActiveRecord::Base
+class Shortener::ShortenedUrl < Shortener::Record
 
   REGEX_LINK_HAS_PROTOCOL = Regexp.new('\Ahttp:\/\/|\Ahttps:\/\/', Regexp::IGNORECASE)
 


### PR DESCRIPTION
Since Rails 6.1+, the `connects_to` method can only be called on ActiveRecord::Base or abstract classes, otherwise, a NotImplementedError will be thrown.

This PR creates a hook to allow connecting to a distinct database, other than the main one.