### PR TITLE
Fixed an issue with links' expiration time.

### DIFF
--- a/spec/shortener/shortened_url_record_spec.rb
+++ b/spec/shortener/shortened_url_record_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Shortener::ShortenedUrl do
+
+  def generate_shortened_link(link, expiration_time)
+    Shortener::ShortenedUrl.generate(link, expires_at: expiration_time)
+  end
+
+  LINKS = ['https://stackoverflow.com',
+           'https://github.com',
+           'https://twitter.com',
+           'https://reddit.com']
+
+  it "returns a default redirect" do
+    expected = { url: Shortener.default_redirect || '/', shortened_url: nil }
+    LINKS.each do |link|
+      shortened_link = generate_shortened_link(link, Time.now)
+      token = shortened_link[:unique_key]
+      out = Shortener::ShortenedUrl.fetch_with_token(token: token)
+      expect(out).to eq expected
+    end
+  end
+end


### PR DESCRIPTION
Today morning i encountered that links' ability to expire does not function properly. Turned out that unexpired links were filtered using ::Time::current::to_s(:db) routine, which outputs incorrect time for my country (3 hour difference).
To mitigate the problem, I just replaced it by ::Time.now. I want to apologize beforehand if there are some issues in the way I wrote the spec test. I'm relatively new to Ruby and am not aware of good practices of writing clean Ruby code.   