### PR TITLE
Let active record format the Time

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -15,7 +15,7 @@ class Shortener::ShortenedUrl < Shortener::Record
   end
 
   # exclude records in which expiration time is set and expiration time is greater than current time
-  scope :unexpired, -> { where(arel_table[:expires_at].eq(nil).or(arel_table[:expires_at].gt(::Time.current.to_s(:db)))) }
+  scope :unexpired, -> { where(arel_table[:expires_at].eq(nil).or(arel_table[:expires_at].gt(::Time.current))) }
 
   attr_accessor :custom_key
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'faker'
 require 'capybara/rspec'
 
 Rails.backtrace_cleaner.remove_silencers!
+ActiveRecord::Base.logger = Logger.new(STDOUT) if ENV['LOG_STDOUT']
 
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|


### PR DESCRIPTION
Don't pre-format the Time passed to the `unexpired` scope. This allows the ActiveRecord adapter to format the date according to it's own needs.

Maybe addresses #144 problems, but it seems like they probably have an incorrectly configured application.

Before SQL:
```
D, [2021-11-30T22:51:27.785105 #91313] DEBUG -- :   Shortener::ShortenedUrl Exists? (0.1ms)  SELECT 1 AS one FROM "shortened_urls" WHERE ("shortened_urls"."expires_at" IS NULL OR "shortened_urls"."expires_at" > '2021-12-01 06:51:27') AND "shortened_urls"."id" = ? LIMIT ?  [["id", 279], ["LIMIT", 1]]
D, [2021-11-30T22:51:27.785193 #91313] DEBUG -- :   ↳ activerecord (6.1.4.1) lib/active_record/log_subscriber.rb:119:in `debug'
D, [2021-11-30T22:51:27.785447 #91313] DEBUG -- :   Shortener::ShortenedUrl Exists? (0.1ms)  SELECT 1 AS one FROM "shortened_urls" WHERE ("shortened_urls"."expires_at" IS NULL OR "shortened_urls"."expires_at" > '2021-12-01 06:51:27') AND "shortened_urls"."id" = ? LIMIT ?  [["id", 278], ["LIMIT", 1]]
D, [2021-11-30T22:51:27.785537 #91313] DEBUG -- :   ↳ activerecord (6.1.4.1) lib/active_record/log_subscriber.rb:119:in `debug'
D, [2021-11-30T22:51:27.785770 #91313] DEBUG -- :   Shortener::ShortenedUrl Exists? (0.0ms)  SELECT 1 AS one FROM "shortened_urls" WHERE ("shortened_urls"."expires_at" IS NULL OR "shortened_urls"."expires_at" > '2021-12-01 06:51:27') AND "shortened_urls"."id" = ? LIMIT ?  [["id", 277], ["LIMIT", 1]]
D, [2021-11-30T22:51:27.785859 #91313] DEBUG -- :   ↳ activerecord (6.1.4.1) lib/active_record/log_subscriber.rb:119:in `debug'
D, [2021-11-30T22:51:27.786130 #91313] DEBUG -- :   Shortener::ShortenedUrl Load (0.2ms)  SELECT "shortened_urls".* FROM "shortened_urls" WHERE ("shortened_urls"."expires_at" IS NULL OR "shortened_urls"."expires_at" > '2021-12-01 06:51:27')
```

After SQL:
```
D, [2021-11-30T22:51:55.141241 #91931] DEBUG -- :   Shortener::ShortenedUrl Exists? (0.1ms)  SELECT 1 AS one FROM "shortened_urls" WHERE ("shortened_urls"."expires_at" IS NULL OR "shortened_urls"."expires_at" > '2021-12-01 06:51:55.136749') AND "shortened_urls"."id" = ? LIMIT ?  [["id", 285], ["LIMIT", 1]]
D, [2021-11-30T22:51:55.141333 #91931] DEBUG -- :   ↳ activerecord (6.1.4.1) lib/active_record/log_subscriber.rb:119:in `debug'
D, [2021-11-30T22:51:55.141578 #91931] DEBUG -- :   Shortener::ShortenedUrl Exists? (0.0ms)  SELECT 1 AS one FROM "shortened_urls" WHERE ("shortened_urls"."expires_at" IS NULL OR "shortened_urls"."expires_at" > '2021-12-01 06:51:55.136749') AND "shortened_urls"."id" = ? LIMIT ?  [["id", 284], ["LIMIT", 1]]
D, [2021-11-30T22:51:55.141661 #91931] DEBUG -- :   ↳ activerecord (6.1.4.1) lib/active_record/log_subscriber.rb:119:in `debug'
D, [2021-11-30T22:51:55.141889 #91931] DEBUG -- :   Shortener::ShortenedUrl Exists? (0.0ms)  SELECT 1 AS one FROM "shortened_urls" WHERE ("shortened_urls"."expires_at" IS NULL OR "shortened_urls"."expires_at" > '2021-12-01 06:51:55.136749') AND "shortened_urls"."id" = ? LIMIT ?  [["id", 283], ["LIMIT", 1]]
D, [2021-11-30T22:51:55.141977 #91931] DEBUG -- :   ↳ activerecord (6.1.4.1) lib/active_record/log_subscriber.rb:119:in `debug'
D, [2021-11-30T22:51:55.142271 #91931] DEBUG -- :   Shortener::ShortenedUrl Load (0.2ms)  SELECT "shortened_urls".* FROM "shortened_urls" WHERE ("shortened_urls"."expires_at" IS NULL OR "shortened_urls"."expires_at" > '2021-12-01 06:51:55.136749')
```