### PR TITLE
Add link to rails doc for load config on boot

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -84,6 +84,8 @@ Then add to your routes:
 == Configuration
 The gem can be configured in a config/initializers/shortener.rb file.
 
+If your using rails > 6.1 checkout {this link}[https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#use-case-1-during-boot-load-reloadable-code] for load config on boot.
+
 By default, the shortener will generate keys that are 5 characters long. You can change that by specifying the length of the key like so;
 
   Shortener.unique_key_length = 6


### PR DESCRIPTION
Add a link to rails documentation usage of load on boot, avoid new users getting warnings on load rails