### PR TITLE
Rails 7 warning

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -15,7 +15,7 @@ class Shortener::ShortenedUrl < Shortener::Record
   end
 
   # exclude records in which expiration time is set and expiration time is greater than current time
-  scope :unexpired, -> { where(arel_table[:expires_at].eq(nil).or(arel_table[:expires_at].gt(::Time.current))) }
+  scope :unexpired, -> { where(arel_table[:expires_at].eq(nil).or(arel_table[:expires_at].gt(::Time.current.to_fs(:db)))) }
 
   attr_accessor :custom_key
 


### PR DESCRIPTION
DEPRECATION WARNING: TimeWithZone#to_s(:db) is deprecated. Please use TimeWithZone#to_fs(:db) instead.