### PR TITLE
Typo in documentation expirable URLs

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -159,11 +159,11 @@ You can pass in your own key when generating a shortened URL. This should be uni
 You can create expirable URLs.
 Probably, most of the time it would be used with owner:
 
-  Shortener::ShortenedUrl.generate("example.com/page", user, expires_at: 24.hours.since)
+  Shortener::ShortenedUrl.generate("example.com/page", user: user, expires_at: 24.hours.since)
 
 You can omit owner passing nil instead:
 
-  Shortener::ShortenedUrl.generate("example.com/page", nil, expires_at: 24.hours.since)
+  Shortener::ShortenedUrl.generate("example.com/page", user: nil, expires_at: 24.hours.since)
 
 === Fresh Links
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -161,7 +161,7 @@ Probably, most of the time it would be used with owner:
 
   Shortener::ShortenedUrl.generate("example.com/page", user: user, expires_at: 24.hours.since)
 
-You can omit owner passing nil instead:
+You can omit owner:
 
   Shortener::ShortenedUrl.generate("example.com/page", expires_at: 24.hours.since)
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -159,7 +159,7 @@ You can pass in your own key when generating a shortened URL. This should be uni
 You can create expirable URLs.
 Probably, most of the time it would be used with owner:
 
-  Shortener::ShortenedUrl.generate("example.com/page", user: user, expires_at: 24.hours.since)
+  Shortener::ShortenedUrl.generate("example.com/page", owner: user, expires_at: 24.hours.since)
 
 You can omit owner:
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -163,7 +163,7 @@ Probably, most of the time it would be used with owner:
 
 You can omit owner passing nil instead:
 
-  Shortener::ShortenedUrl.generate("example.com/page", user: nil, expires_at: 24.hours.since)
+  Shortener::ShortenedUrl.generate("example.com/page", expires_at: 24.hours.since)
 
 === Fresh Links
 


### PR DESCRIPTION
Hello, I just stumbled on to this while trying the library.

When  using:
```
 Shortener::ShortenedUrl.generate("example.com/page", nil, expires_at: 24.hours.since)
```
There is a `Too many argument error, got 2 expecting 1`

I think we can omit the owner completely at line 166,
like so:
```
You can omit owner:

Shortener::ShortenedUrl.generate("example.com/page", expires_at: 24.hours.since)
```