### PR TITLE
Upgrade voight_kampff to 2.0 (ruby 3 compatible)

### DIFF
--- a/lib/shortener/engine.rb
+++ b/lib/shortener/engine.rb
@@ -1,5 +1,7 @@
+require "rack"
 require "rails/engine"
 require "voight_kampff"
+require "voight_kampff/rails"
 require "shortener"
 
 class Shortener::Engine < ::Rails::Engine #:nodoc:

--- a/shortener.gemspec
+++ b/shortener.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage                  = "http://jamespmcgrath.com/projects/shortener"
   s.required_rubygems_version = "> 2.1.0"
 
-  s.add_dependency "voight_kampff", '~> 1.1.2'
+  s.add_dependency "voight_kampff", '~> 2.0'
 
   s.add_development_dependency "rails", '>= 3'
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Fixes https://github.com/jpmcgrath/shortener/issues/151

I was getting
```
NoMethodError in Shortener::ShortenedUrlsController#show
undefined method `exists?' for File:Class
```
when using this gem with ruby 3.2.1,
the error was caused voight_kampff using `File.exists?` (removed in Ruby 3) instead of `File.exist?`.

This was fixed in the 2.0 release of voight_kampff
https://github.com/biola/Voight-Kampff/commit/b24e698959c1fa1470f59a26a022461c8f35d26d

rspec tests passed
```
$ /usr/local/rvm/gems/ruby-3.2.1/bin/bundle exec rspec
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
DEPRECATION WARNING: Using legacy connection handling is deprecated. Please set
`legacy_connection_handling` to `false` in your application.

The new connection handling does not support `connection_handlers`
getter and setter.

Read more about how to migrate at: https://guides.rubyonrails.org/active_record_multiple_databases.html#migrate-to-the-new-connection-handling
 (called from <top (required)> at /workspaces/shortener/spec/spec_helper.rb:29)
.......................................................................................................................

Finished in 3.09 seconds (files took 1.65 seconds to load)
119 examples, 0 failures
```