### PR TITLE
Use the writing role for increment_usage_count

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -260,13 +260,27 @@ If you want more things to happen when a user accesses one of your short urls, y
 
 You can store a `shortened_urls` table in another database and connecting to it by creating a initializer with the following:
 
-```ruby
-ActiveSupport.on_load(:shortener_record) do
-  connects_to(database: { writing: :dbname, reading: :dbname_replica })
-end
-```
+    ActiveSupport.on_load(:shortener_record) do
+      connects_to(database: { writing: :dbname, reading: :dbname_replica })
+    end
 
 **Note:** Please, replace `dbname` and `dbname_replica` to match your database configuration.
+
+=== Configuring Reader and Writer Multi-DB Roles
+
+Shortener has one write operation that happens on a GET request. To allow this you can override this method in an initializer.
+
+    module ShortenerWriterMonkeyPatch
+      def increment_usage_count
+        ActiveRecord::Base.connected_to(role: :writing) do
+          self.class.increment_counter(:use_count, id)
+        end
+      end
+    end
+
+    ActiveSupport.on_load(:shortener_shortened_url) do
+      Shortener::ShortenedUrl.prepend(ShortenerWriterMonkeyPatch)
+    end
 
 == Contributing
 

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -117,7 +117,11 @@ class Shortener::ShortenedUrl < Shortener::Record
   end
 
   def increment_usage_count
-    ActiveRecord::Base.connected_to(role: :writing) do
+    if ActiveRecord::Base.respond_to?(:connected_to)
+      ActiveRecord::Base.connected_to(role: :writing) do
+        self.class.increment_counter(:use_count, id)
+      end
+    else
       self.class.increment_counter(:use_count, id)
     end
   end

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -117,13 +117,7 @@ class Shortener::ShortenedUrl < Shortener::Record
   end
 
   def increment_usage_count
-    if ActiveRecord::Base.respond_to?(:connected_to)
-      ActiveRecord::Base.connected_to(role: :writing) do
-        self.class.increment_counter(:use_count, id)
-      end
-    else
-      self.class.increment_counter(:use_count, id)
-    end
+    self.class.increment_counter(:use_count, id)
   end
 
   def to_param
@@ -153,3 +147,5 @@ class Shortener::ShortenedUrl < Shortener::Record
     end
   end
 end
+
+ActiveSupport.run_load_hooks :shortener_shortened_url, Shortener::ShortenedUrl

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -117,7 +117,9 @@ class Shortener::ShortenedUrl < Shortener::Record
   end
 
   def increment_usage_count
-    self.class.increment_counter(:use_count, id)
+    ActiveRecord::Base.connected_to(role: :writing) do
+      self.class.increment_counter(:use_count, id)
+    end
   end
 
   def to_param


### PR DESCRIPTION
Within my app I'm having an issue where shortener is writing during a GET request and we need to specifically use the writing role to `increment_usage_count`.

All of the spec pass and the test application does not have any special setup for multi-db so I suspect this will have no issues unless there is some way to name the writing role differently.

I am open to other suggestions, like using an initializer but I'm unsure the best approach.

This is in regards to my issue #169 .