### PR TITLE
feat: Custom Tracking Strategies

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -106,6 +106,18 @@ You can control this option if it interferes for any of your logic. One common c
 
   Shortener.auto_clean_url = true
 
+By default, Shortener will track utilization of shortened URLs. This value is stored as an integer in the +use_count+ column.
+You can override this behaviour as necessary for your application:
+
+  Shortener.increment_usage_count = ->(url) do
+    # move the operation to a background job (your application defines the job class)
+    UrlTrackingJob.perform_later(url)
+  end
+
+Alternatively tracking can be disabled entirely with the following configuration:
+
+  Shortener.increment_usage_count = ->(_url) {} # turn into a no-op
+
 == Usage
 
 To generate a Shortened URL object for the URL "http://example.com" within your controller / models do the following:
@@ -268,18 +280,13 @@ You can store a `shortened_urls` table in another database and connecting to it 
 
 === Configuring Reader and Writer Multi-DB Roles
 
-Shortener has one write operation that happens on a GET request. To allow this you can override this method in an initializer.
+By default shortener will perform one write operation per GET request. You can configure a custom database role as follows:
 
-    module ShortenerWriterMonkeyPatch
-      def increment_usage_count
-        ActiveRecord::Base.connected_to(role: :writing) do
-          self.class.increment_counter(:use_count, id)
-        end
+    # config/initializers/shortener.rb
+    Shortener.increment_usage_count = ->(url) do
+      ActiveRecord::Base.connected_to(role: :writing) do
+        url.class.increment_counter(:use_count, url.id)
       end
-    end
-
-    ActiveSupport.on_load(:shortener_shortened_url) do
-      Shortener::ShortenedUrl.prepend(ShortenerWriterMonkeyPatch)
     end
 
 == Contributing

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -117,7 +117,7 @@ class Shortener::ShortenedUrl < Shortener::Record
   end
 
   def increment_usage_count
-    self.class.increment_counter(:use_count, id)
+    Shortener.increment_usage_count.call(self)
   end
 
   def to_param

--- a/lib/shortener.rb
+++ b/lib/shortener.rb
@@ -45,6 +45,13 @@ module Shortener
   mattr_accessor :auto_clean_url
   self.auto_clean_url = true
 
+  # increment_usage_count - strategy used to increment usage count, defined as
+  # a lambda that accepts the Shortener::ShortenedUrl record as an argument
+  mattr_accessor :increment_usage_count
+  self.increment_usage_count = ->(url) do
+    url.class.increment_counter(:use_count, url.id)
+  end
+
   def self.key_chars
     charset.is_a?(Symbol) ? CHARSETS[charset] : charset
   end

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -229,10 +229,26 @@ describe Shortener::ShortenedUrl, type: :model do
   describe '#increment_usage_count' do
     let(:url) { 'https://example.com'}
     let(:short_url) { Shortener::ShortenedUrl.generate!(url) }
+    
     it 'increments the use_count on the shortenedLink' do
       original_count = short_url.use_count
       short_url.increment_usage_count
       expect(short_url.reload.use_count).to eq (original_count + 1)
+    end
+
+    context 'with usage count disabled' do
+      around(:each) do |example|
+        original = Shortener.increment_usage_count
+        Shortener.increment_usage_count = ->(_record) {} # no-op
+        example.run
+        Shortener.increment_usage_count = original
+      end
+
+      it 'returns the original usage count' do
+        original_count = short_url.use_count
+        short_url.increment_usage_count
+        expect(short_url.reload.use_count).to eq(original_count)
+      end
     end
   end
 


### PR DESCRIPTION
Hey there! Thanks for making an awesome library!

I recently ran into a use case where it would be convenient to introduce an alternate strategy when updating the `use_count` column.  In particular, the goal was to move the write database operation out of the request lifecycle into a background job. 

Previously this customization would require a monkey patch of the `Shortener::ShortenedUrl#increment_usage_count` method (similar the approach taken in #170).

This PR adds a new configuration option to make it simple to specify the tracking behaviour. The option default doesn't break existing functionality, and operates as follows:

```ruby
Shortener.increment_usage_count = ->(url) do
  MyBackgroundJob.perform_later(url)
end
```

Happy to hear any feedback or suggestions, but it seems like this could be a useful addition to the library. Thanks!