### PR TITLE
Turn off fail fast, as we want to see which matrix combox succeed

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        ruby-version: 
+        ruby-version:
           - '2.4'
           - '2.7'
           - '3.0'


### PR DESCRIPTION
Github provides "unlimited" build minutes to open source projects, and it is useful to see with matrix combos are succeeding.

By seeing the results of all matrix runs, we will more easily idenify and resolve various build problems.

https://github.com/orgs/community/discussions/70492