### PR TITLE
concurrent-ruby v1.3.5 has removed the dependency on logger

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -12,14 +12,17 @@ end
 
 appraise "rails_6.0" do
   gem "rails", "~> 6.0.0"
+  gem 'concurrent-ruby', '1.3.4'
 end
 
 appraise "rails_6.1" do
   gem "rails", "~> 6.1.0"
+  gem 'concurrent-ruby', '1.3.4'
 end
 
 appraise "rails_7.0" do
   gem "rails", "~> 7.0.0"
+  gem 'concurrent-ruby', '1.3.4'
 end
 
 appraise "rails_7.1" do

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.0.0"
+gem 'concurrent-ruby', '1.3.4'
 
 gemspec path: "../"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
+gem 'concurrent-ruby', '1.3.4'
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
+gem 'concurrent-ruby', '1.3.4'
 
 gemspec path: "../"

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,3 +1,4 @@
+require 'logger'
 require 'rubygems'
 gemfile = File.expand_path('../../../../Gemfile', __FILE__)
 

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,4 +1,3 @@
-require 'logger'
 require 'rubygems'
 gemfile = File.expand_path('../../../../Gemfile', __FILE__)
 


### PR DESCRIPTION
Build is [failing](https://github.com/jpmcgrath/shortener/actions/runs/18649129464/job/53162834509) with error:

```
Failure/Error: require "active_support"

NameError:
  uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
# ./vendor/bundle/ruby/3.0.0/gems/activesupport-6.0.6.1/lib/active_support/logger_thread_safe_level.rb:16:in `<module:LoggerThreadSafeLevel>'
``` 

This is due to `concurrent-ruby` v1.3.5 has removed the dependency on logger. This is fixed in Rails 7.1, so for earlier versions pin the version of `concurrent-ruby` to v1.3.4.

https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror

